### PR TITLE
Allow $jsonable to be filled into model automatically

### DIFF
--- a/behaviors/IndexModelFormOperations.php
+++ b/behaviors/IndexModelFormOperations.php
@@ -72,12 +72,10 @@ class IndexModelFormOperations extends IndexOperationsBehaviorBase
 
         // Get JSONable fields and store these in the main model
         $jsonable = $model->getJsonableFields();
-        if (count($jsonable)) {
-            $modelClass = new ModelModel();
-            $modelClass->setPluginCode(Request::input('plugin_code'));
-            $modelClass->className = Request::input('model_class');
-            $modelClass->setJsonable($jsonable);
-        }
+        $modelClass = new ModelModel();
+        $modelClass->setPluginCode(Request::input('plugin_code'));
+        $modelClass->className = Request::input('model_class');
+        $modelClass->setJsonable($jsonable);
 
         $result = $this->controller->widget->modelList->updateList();
 

--- a/classes/ModelFileParser.php
+++ b/classes/ModelFileParser.php
@@ -182,9 +182,7 @@ class ModelFileParser extends PhpFileParser
             $property->setDocComment(new Doc(
                 "\n"
                 . "/**\n"
-                . " * JSONable fields.\n"
-                . " *\n"
-                . " * @var array\n"
+                . " * @var array Attribute names to encode and decode using JSON.\n"
                 . " */"
             ));
 

--- a/classes/ModelFileParser.php
+++ b/classes/ModelFileParser.php
@@ -1,200 +1,168 @@
 <?php namespace Winter\Builder\Classes;
 
+use ApplicationException;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\Cast\Bool_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\PropertyProperty;
+use PhpParser\Node\VarLikeIdentifier;
+use PhpParser\NodeFinder;
+
 /**
- * Parses models source files.
+ * Parses and manipulates model files.
  *
  * @package winter\builder
  * @author Alexey Bobkov, Samuel Georges
+ * @author Winter CMS
  */
-class ModelFileParser
+class ModelFileParser extends PhpFileParser
 {
     /**
      * Returns the model namespace, class name and table name.
-     * @param string $fileContents Specifies the file contents.
-     * @return array|null Returns an array with keys 'namespace', 'class' and 'table'
-     * Returns null if the parsing fails.
+     *
+     * @return array|null Returns an array with keys 'namespace', 'class' and 'table'. Returns `null` if the parsing
+     *  fails.
      */
-    public function extractModelInfoFromSource($fileContents)
+    public function extractModelInfoFromSource()
     {
-        $stream = new PhpSourceStream($fileContents);
-
         $result = [];
+        $finder = new NodeFinder;
 
-        while ($stream->forward()) {
-            $tokenCode = $stream->getCurrentCode();
+        // Get the namespace
+        $namespace = $finder->findFirstInstanceOf($this->ast, Namespace_::class);
 
-            if ($tokenCode == T_NAMESPACE) {
-                $namespace = $this->extractNamespace($stream);
-                if ($namespace === null) {
-                    return null;
-                }
-
-                $result['namespace'] = $namespace;
-            }
-
-            if ($tokenCode == T_CLASS && !isset($result['class'])) {
-                $className = $this->extractClassName($stream);
-                if ($className === null) {
-                    return null;
-                }
-
-                $result['class'] = $className;
-            }
-
-            if ($tokenCode == T_PUBLIC || $tokenCode == T_PROTECTED) {
-                $tableName = $this->extractTableName($stream);
-                if ($tableName === false) {
-                    continue;
-                }
-
-                if ($tableName === null) {
-                    return null;
-                }
-
-                $result['table'] = $tableName;
-            }
+        if ($namespace === null) {
+            return null;
         }
 
-        if (!$result) {
+        $result['namespace'] = $namespace->name->toString();
+
+        // Get the class name
+        $class = $finder->findFirstInstanceOf($this->ast, Class_::class);
+
+        if ($class === null) {
             return null;
+        }
+
+        $result['class'] = $class->name->toString();
+        $result['fqClass'] = Name::concat($namespace->name, $class->name->toString());
+
+        // Get the table name
+        $tableName = $finder->findFirst($class, function (Node $node) {
+            return (
+                $node instanceof PropertyProperty
+                && $node->name instanceof VarLikeIdentifier
+                && $node->name->name === 'table'
+            );
+        });
+
+        if (
+            $tableName === null
+            || (
+                $tableName->default instanceof String_ === false
+                && $tableName->default instanceof Bool_ === false
+            )
+        ) {
+            return null;
+        }
+
+        if ($tableName->default instanceof String_) {
+            $result['table'] = $tableName->default->value;
         }
 
         return $result;
     }
 
     /**
-     * Extracts names and types of model relations.
-     * @param string $fileContents Specifies the file contents.
-     * @return array|null Returns an array with keys matching the relation types and values containing relation names as array.
-     * Returns null if the parsing fails.
+     * Gets the value of the $jsonable property, if available.
+     *
+     * @return array|null
      */
-    public function extractModelRelationsFromSource($fileContents)
+    public function getJsonable()
     {
-        $result = [];
+        $finder = new NodeFinder;
 
-        $stream = new PhpSourceStream($fileContents);
+        $class = $finder->findFirstInstanceOf($this->ast, Class_::class);
 
-        while ($stream->forward()) {
-            $tokenCode = $stream->getCurrentCode();
+        if ($class === null) {
+            return null;
+        }
 
-            if ($tokenCode == T_PUBLIC) {
-                $relations = $this->extractRelations($stream);
-                if ($relations === false) {
-                    continue;
-                }
+        $jsonable = $finder->findFirst($class, function (Node $node) {
+            return (
+                $node instanceof PropertyProperty
+                && $node->name instanceof VarLikeIdentifier
+                && $node->name->name === 'jsonable'
+            );
+        });
+
+        if ($jsonable === null || $jsonable->default instanceof Array_ === false) {
+            return null;
+        }
+
+        $columns = [];
+
+        foreach ($jsonable->default->items as $item) {
+            if ($item->value instanceof String_) {
+                $columns[] = $item->value->value;
+            } elseif (method_exists($item->value, 'toString')) {
+                $columns[] = $item->value->toString();
             }
         }
 
-        if (!$result) {
-            return null;
-        }
-
-        return $result;
+        return $columns;
     }
 
     /**
-     * extractNamespace from model info
+     * Sets the value of the $jsonable property for a model.
+     *
+     * If the property does not exist, it will be added.
+     *
+     * @param array $columns
+     * @return void
+     * @throws ApplicationException If the property cannot be created, ie. this is not a class.
      */
-    protected function extractNamespace($stream)
+    public function setJsonable(array $columns)
     {
-        if ($stream->getNextExpected(T_WHITESPACE) === null) {
-            return null;
+        $finder = new NodeFinder;
+
+        $class = $finder->findFirstInstanceOf($this->ast, Class_::class);
+
+        if ($class === null) {
+            throw new ApplicationException(
+                sprintf(
+                    'File "%s" does not appear to be a class, and cannot have the $jsonable property written',
+                    $this->filePath
+                )
+            );
         }
 
-        $expected = [T_STRING, T_NS_SEPARATOR];
+        $jsonable = $finder->findFirst($class, function (Node $node) {
+            return (
+                $node instanceof PropertyProperty
+                && $node->name instanceof VarLikeIdentifier
+                && $node->name->name === 'jsonable'
+            );
+        });
 
-        // Namespace string on PHP 8.0 returns code 314 (T_NAME_QUALIFIED)
-        // @deprecated combine when min req > php 8
-        if (defined('T_NAME_QUALIFIED') && T_NAME_QUALIFIED > 0) {
-            $expected[] = T_NAME_QUALIFIED;
+        if ($jsonable === null) {
+            // We must create the property
+
+            return;
         }
 
-        return $stream->getNextExpectedTerminated($expected, [T_WHITESPACE, ';']);
-    }
+        // Reset $jsonable property and add new columns
+        $jsonable->default->items = [];
 
-    /**
-     * extractClassName from model info
-     */
-    protected function extractClassName($stream)
-    {
-        if ($stream->getNextExpected(T_WHITESPACE) === null) {
-            return null;
+        foreach ($columns as $column) {
+            $jsonable->default->items[] = new ArrayItem(
+                new String_($column)
+            );
         }
-
-        return $stream->getNextExpectedTerminated([T_STRING], [T_WHITESPACE, ';']);
-    }
-
-    /**
-     * Returns the table name. This method would return null in case if the
-     * $table variable was found, but it value cannot be read. If the variable
-     * is not found, the method returns false, allowing the outer loop to go to
-     * the next token.
-     */
-    protected function extractTableName($stream)
-    {
-        if ($stream->getNextExpected(T_WHITESPACE) === null) {
-            return false;
-        }
-
-        if ($stream->getNextExpected(T_VARIABLE) === null) {
-            return false;
-        }
-
-        if ($stream->getCurrentText() != '$table') {
-            return false;
-        }
-
-        if ($stream->getNextExpectedTerminated(['=', T_WHITESPACE], [T_CONSTANT_ENCAPSED_STRING]) === null) {
-            return null;
-        }
-
-        $tableName = $stream->getCurrentText();
-        $tableName = trim($tableName, '\'');
-        $tableName = trim($tableName, '"');
-
-        return $tableName;
-    }
-
-    protected function extractRelations($stream)
-    {
-        if ($stream->getNextExpected(T_WHITESPACE) === null) {
-            return false;
-        }
-
-        if ($stream->getNextExpected(T_VARIABLE) === null) {
-            return false;
-        }
-
-        $relationTypes = [
-            'belongsTo',
-            'belongsToMany',
-            'attachMany',
-            'hasMany',
-            'morphToMany',
-            'morphedByMany',
-            'morphMany',
-            'hasManyThrough'
-        ];
-
-        $relationType = null;
-        $currentText = $stream->getCurrentText();
-
-        foreach ($relationTypes as $type) {
-            if ($currentText == '$'.$type) {
-                $relationType = $type;
-                break;
-            }
-        }
-
-        if (!$relationType) {
-            return false;
-        }
-
-        if ($stream->getNextExpectedTerminated(['=', T_WHITESPACE], ['[']) === null) {
-            return null;
-        }
-
-        // The implementation is not finished and postponed. Relation definition could
-        // be quite complex and contain nested arrays.
     }
 }

--- a/classes/ModelFormModel.php
+++ b/classes/ModelFormModel.php
@@ -8,6 +8,7 @@ use ValidationException;
  *
  * @package winter\builder
  * @author Alexey Bobkov, Samuel Georges
+ * @author Winter CMS
  */
 class ModelFormModel extends ModelYamlModel
 {
@@ -40,6 +41,72 @@ class ModelFormModel extends ModelYamlModel
         }
 
         return parent::fill($attributes);
+    }
+
+    /**
+     * Determines the fields that should be stored as "jsonable" data.
+     *
+     * @return array
+     */
+    public function getJsonableFields()
+    {
+        $fields = [];
+
+        // Search outside fields
+        if (isset($this->controls['fields']) && count($this->controls['fields'])) {
+            $this->scanJsonableFields($fields, $this->controls['fields']);
+        }
+
+        // Search primary tabs fields
+        if (isset($this->controls['tabs']['fields']) && count($this->controls['tabs']['fields'])) {
+            $this->scanJsonableFields($fields, $this->controls['tabs']['fields']);
+        }
+
+        // Search secondary tabs fields
+        if (isset($this->controls['secondaryTabs']['fields']) && count($this->controls['secondaryTabs']['fields'])) {
+            $this->scanJsonableFields($fields, $this->controls['secondaryTabs']['fields']);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Scans for "jsonable" fields within a fieldset and adds them to the found array.
+     *
+     * @param array $found
+     * @param array $fields
+     * @return void
+     */
+    protected function scanJsonableFields(array &$found, array $fields)
+    {
+        $jsonableFields = [
+            'checkboxlist',
+            'datatable',
+            'nestedform',
+            'repeater',
+        ];
+
+        foreach ($fields as $name => $field) {
+            // Skip related fields
+            if (str_contains($name, '[')) {
+                continue;
+            }
+
+            if (in_array($field['type'], $jsonableFields)) {
+                if (!array_key_exists($name, $found)) {
+                    $found[] = $name;
+                    continue;
+                }
+            }
+
+            // Allow for multi-selection dropdowns
+            if ($field['type'] === 'dropdown' && $field['multiple'] === true) {
+                if (!array_key_exists($name, $found)) {
+                    $found[] = $name;
+                    continue;
+                }
+            }
+        }
     }
 
     public static function validateFileIsModelType($fileContentsArray)

--- a/classes/PhpFileParser.php
+++ b/classes/PhpFileParser.php
@@ -1,0 +1,101 @@
+<?php namespace Winter\Builder\Classes;
+
+use File;
+use ApplicationException;
+use PhpParser\Error;
+use PhpParser\Lexer\Emulative;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard;
+
+/**
+ * PHP File Parser.
+ *
+ * Simplifies modifications and parsing of PHP files, using the "nikic/php-parser" library.
+ *
+ * @author Winter CMS
+ */
+abstract class PhpFileParser
+{
+    /**
+     * @var \PhpParser\Node\Stmt[] The abstract syntax tree of the given PHP file, cloned for manipulation.
+     */
+    protected $ast;
+
+    /**
+     * @var array Tokens from the given PHP file, used for manipulation.
+     */
+    protected $originalTokens;
+
+    /**
+     * @var \PhpParser\Node\Stmt[] The abstract syntax tree of the given PHP file, as originally defined.
+     */
+    protected $originalAst;
+
+    /**
+     * @var \PhpParser\NodeTraverser The traverser used for add context for nodes.
+     */
+    protected $traverser;
+
+    /**
+     * @var \PhpParser\Lexer\Emulative The lexer used to manipulate code.
+     */
+    protected $lexer;
+
+    /**
+     * @var string The path to the parsed file.
+     */
+    protected $filePath;
+
+    /**
+     * Constructor.
+     *
+     * Automatically parses the given file.
+     */
+    public function __construct(string $file)
+    {
+        if (!File::exists($file) || File::extension($file) !== 'php') {
+            throw new ApplicationException(
+                sprintf('File "%s" is not a valid PHP file to parse.', $file)
+            );
+        }
+
+        $this->lexer = new Emulative([
+            'usedAttributes' => [
+                'comments',
+                'startLine', 'endLine',
+                'startTokenPos', 'endTokenPos',
+            ],
+        ]);
+
+        $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7, $this->lexer);
+
+        try {
+            $this->originalAst = $parser->parse(File::get($file));
+        } catch (Error $e) {
+            throw new ApplicationException(
+                sprintf('Unable to parse PHP file "%s". (%s)', $file, $e->getMessage())
+            );
+        }
+
+        $this->originalTokens = $this->lexer->getTokens();
+        $this->traverser = new NodeTraverser;
+        $this->traverser->addVisitor(new CloningVisitor);
+        $this->ast = $this->traverser->traverse($this->originalAst);
+
+        $this->filePath = $file;
+    }
+
+    /**
+     * Returns the pretty-printed source based off the cloned AST.
+     *
+     * @return string
+     */
+    public function getSource()
+    {
+        $printer = new Standard();
+
+        return $printer->printFormatPreserving($this->ast, $this->originalAst, $this->originalTokens);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     },
     "require": {
         "php": ">=7.0",
-        "composer/installers": "~1.0"
+        "composer/installers": "~1.0",
+        "nikic/php-parser": "^4.13.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/formwidgets/FormBuilder.php
+++ b/formwidgets/FormBuilder.php
@@ -56,10 +56,10 @@ class FormBuilder extends FormWidgetBase
      */
     public function loadAssets()
     {
-        $this->addJs('js/formbuilder.js', 'builder');
-        $this->addJs('js/formbuilder.domtopropertyjson.js', 'builder');
-        $this->addJs('js/formbuilder.tabs.js', 'builder');
-        $this->addJs('js/formbuilder.controlpalette.js', 'builder');
+        $this->addJs('js/formbuilder.js', 'Winter.Builder');
+        $this->addJs('js/formbuilder.domtopropertyjson.js', 'Winter.Builder');
+        $this->addJs('js/formbuilder.tabs.js', 'Winter.Builder');
+        $this->addJs('js/formbuilder.controlpalette.js', 'Winter.Builder');
     }
 
     public function renderControlList($controls, $listName = '')

--- a/tests/fixtures/pluginfixture/models/ArrayDataModel.php
+++ b/tests/fixtures/pluginfixture/models/ArrayDataModel.php
@@ -1,0 +1,32 @@
+<?php namespace Winter\Builder\Tests\Fixtures\PluginFixture\Models;
+
+use Model;
+
+class ArrayDataModel extends Model
+{
+    /**
+     * Database table.
+     *
+     * @var string
+     */
+    public $table = 'plugin_fixture_array_data_model';
+
+    /**
+     * JSONable fields.
+     *
+     * @var array
+     */
+    public $jsonable = [
+        'data',
+    ];
+
+    /**
+     * Used to make sure that the "setJsonable" method doesn't mess with the source code too much
+     *
+     * @return void
+     */
+    public function methodName()
+    {
+        return 'This is a test method';
+    }
+}

--- a/tests/fixtures/pluginfixture/models/SimpleModel.php
+++ b/tests/fixtures/pluginfixture/models/SimpleModel.php
@@ -10,4 +10,14 @@ class SimpleModel extends Model
      * @var string
      */
     public $table = 'plugin_fixture_simple_model';
+
+    /**
+     * Used to make sure that the "setJsonable" method doesn't mess with the source code too much
+     *
+     * @return void
+     */
+    public function methodName()
+    {
+        return 'This is a test method';
+    }
 }

--- a/tests/unit/classes/ModelFileParserTest.php
+++ b/tests/unit/classes/ModelFileParserTest.php
@@ -7,26 +7,46 @@ use Winter\Builder\Classes\ModelFileParser;
  */
 class ModelFileParserTest extends \TestCase
 {
-    /**
-     * ModelFileParser instance
-     *
-     * @var ModelFileParser
-     */
-    protected $modelFileParser;
-
-    public function setUp(): void
-    {
-        $this->modelFileParser = new ModelFileParser();
-    }
-
     public function testExtractModelInfoFromSource()
     {
-        $modelInfo = $this->modelFileParser->extractModelInfoFromSource(
-            file_get_contents(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php')
-        );
+        $parser = new ModelFileParser(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php');
+        $modelInfo = $parser->extractModelInfoFromSource();
 
         $this->assertEquals('Winter\Builder\Tests\Fixtures\PluginFixture\Models', $modelInfo['namespace']);
         $this->assertEquals('SimpleModel', $modelInfo['class']);
         $this->assertEquals('plugin_fixture_simple_model', $modelInfo['table']);
+    }
+
+    public function testGetSource()
+    {
+        $parser = new ModelFileParser(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php');
+        $source = $parser->getSource();
+
+        $this->assertEquals(file_get_contents(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php'), $source);
+    }
+
+    public function testGetJsonable()
+    {
+        $parser = new ModelFileParser(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php');
+        $jsonable = $parser->getJsonable();
+        $this->assertNull($jsonable);
+
+        $parser = new ModelFileParser(__DIR__ . '/../../fixtures/pluginfixture/models/ArrayDataModel.php');
+        $jsonable = $parser->getJsonable();
+        $this->assertEquals([
+            'data',
+        ], $jsonable);
+    }
+
+    public function testSetJsonable()
+    {
+        $parser = new ModelFileParser(__DIR__ . '/../../fixtures/pluginfixture/models/ArrayDataModel.php');
+        $parser->setJsonable([
+            'field_1',
+            'field_2',
+        ]);
+        $source = $parser->getSource();
+
+        $this->assertStringContainsString('public $jsonable = [\'field_1\', \'field_2\'];', $source);
     }
 }

--- a/tests/unit/classes/ModelFileParserTest.php
+++ b/tests/unit/classes/ModelFileParserTest.php
@@ -49,4 +49,16 @@ class ModelFileParserTest extends \TestCase
 
         $this->assertStringContainsString('public $jsonable = [\'field_1\', \'field_2\'];', $source);
     }
+
+    public function testSetJsonableAddProperty()
+    {
+        $parser = new ModelFileParser(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php');
+        $parser->setJsonable([
+            'field_1',
+            'field_2',
+        ]);
+        $source = $parser->getSource();
+
+        $this->assertStringContainsString('public $jsonable = [\'field_1\', \'field_2\'];', $source);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/wintercms/wn-builder-plugin/issues/21

This PR introduces simple PHP file manipulation through the PHP Parser library, and adds the ability for the Builder plugin to insert (or modify) a `$jsonable` property in a model, with the intention of populating this with column names for field types that need it (ie. repeater, multi-selection widgets, nested forms, etc.)

The pretty-printing in the PHP Parser library seems to be pretty good and not touching the code outside of any manipulated areas, but it's less good at making sure any *new* code matches the same coding style, so there is a trade-off here in that any inserted code might not look quite right in the context of the rest of the file, but the rest of the code around it should be left untouched. However, I think this will be fine for people using the Builder.