### PR TITLE
Show model linked to database tables

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -87,7 +87,9 @@ return [
         'error_unsigned_negative_value' => "The default value for the unsigned column ':column' can't be negative.",
         'error_table_already_exists' => "The table ':name' already exists in the database.",
         'error_table_name_too_long' => "The table name should not be longer than 64 characters.",
-        'error_column_name_too_long' => "The column name ':column' is too long. Column names should not be longer than 64 characters."
+        'error_column_name_too_long' => "The column name ':column' is too long. Column names should not be longer than 64 characters.",
+        'unlinked_table' => 'No model linked',
+        'linked_model' => ':model model table',
     ],
     'model' => [
         'menu_label' => 'Models',

--- a/widgets/DatabaseTableList.php
+++ b/widgets/DatabaseTableList.php
@@ -19,6 +19,8 @@ class DatabaseTableList extends WidgetBase
     protected $theme;
 
     public $noRecordsMessage = 'winter.builder::lang.database.no_records';
+    public $unlinkedTableMessage = 'winter.builder::lang.database.unlinked_table';
+    public $linkedModelMessage = 'winter.builder::lang.database.linked_model';
 
     public function __construct($controller, $alias)
     {

--- a/widgets/databasetablelist/partials/_items.htm
+++ b/widgets/databasetablelist/partials/_items.htm
@@ -1,13 +1,18 @@
 <?php if ($items): ?>
     <ul>
         <?php foreach ($items as $table):
-            $dataId = 'databaseTable-'.$table;
+            $dataId = 'databaseTable-' . $table['table'];
         ?>
-            <li class="item" 
-                data-id="<?= e($dataId) ?>" 
+            <li class="item"
+                data-id="<?= e($dataId) ?>"
             >
-                <a href="#" data-builder-command="databaseTable:cmdOpenTable" data-id="<?= e($table) ?>">
-                    <span class="title"><?= e($table) ?></span>
+                <a href="#" data-builder-command="databaseTable:cmdOpenTable" data-id="<?= e($table['table']) ?>">
+                    <span class="title"><?= e($table['table']) ?></span>
+                    <?php if (is_null($table['model'])): ?>
+                        <span class="description unlinked"><?= e(trans($this->unlinkedTableMessage)) ?></span>
+                    <?php else: ?>
+                        <span class="description"><?= e(trans($this->linkedModelMessage, ['model' => $table['model']])) ?></span>
+                    <?php endif ?>
                     <span class="borders"></span>
                 </a>
             </li>


### PR DESCRIPTION
![Screenshot 2022-03-13 at 22-10-41 Builder Winter CMS](https://user-images.githubusercontent.com/15900351/158063668-fcb0f613-816d-41a2-8c26-88e6a659024c.png)

Simple UX tweak to the database table list that shows the linked model's name underneath each database table.