### PR TITLE
Fix error in search

### DIFF
--- a/widgets/DatabaseTableList.php
+++ b/widgets/DatabaseTableList.php
@@ -90,7 +90,7 @@ class DatabaseTableList extends WidgetBase
             $result = [];
 
             foreach ($tables as $table) {
-                if ($this->textMatchesSearch($words, $table)) {
+                if ($this->textMatchesSearch($words, $table['table'])) {
                     $result[] = $table;
                 }
             }


### PR DESCRIPTION
Minor fix in search table list.

"mb_strtolower() expects parameter 1 to be string, array given" on line 321 of /vendor/laravel/framework/src/Illuminate/Support/Str.php
