### PR TITLE
Add control condition on drop column

### DIFF
--- a/classes/TableMigrationCodeGenerator.php
+++ b/classes/TableMigrationCodeGenerator.php
@@ -335,7 +335,10 @@ class TableMigrationCodeGenerator extends BaseModel
 
     protected function generateColumnDrop($column)
     {
-        return sprintf('\t\t$table->dropColumn(\'%s\');', $column->getName()).$this->eol;
+        $code  = sprintf('\t\tif (Schema::hasColumn($table->getTable(),  \'%s\' )) {', $column->getName()).$this->eol;
+        $code .= sprintf('\t\t\t$table->dropColumn(\'%s\');', $column->getName()).$this->eol;
+        $code .= '\t\t};'.$this->eol;
+        return $code;
     }
 
     protected function generateIndexDrop($index)
@@ -408,7 +411,10 @@ class TableMigrationCodeGenerator extends BaseModel
 
     protected function generateColumnRemoveCode($name)
     {
-        return sprintf('\t\t$table->dropColumn(\'%s\');', $name).$this->eol;
+        $code  = sprintf('\t\tif (Schema::hasColumn($table->getTable(),  \'%s\' )) {', $column->getName()).$this->eol;
+        $code .= sprintf('\t\t\t$table->dropColumn(\'%s\');', $column->getName()).$this->eol;
+        $code .= '\t\t};'.$this->eol;
+        return $code;
     }
 
     protected function generateColumnMethodCall($column)


### PR DESCRIPTION
Add check with hasColumn schema method before drop column

When running unit test by default it will use an in-memory SQLite database that may or may not have already applied that migration
 