### PR TITLE
spaceless tag replaced with apply filter

### DIFF
--- a/components/recordlist/default.htm
+++ b/components/recordlist/default.htm
@@ -9,7 +9,7 @@
     {% for record in records %}
         <li>
             {# Use spaceless tag to remove spaces inside the A tag. #}
-            {% spaceless %}
+            {% apply spaceless %}
                 {% if detailsPage %}
                     <a href="{{ detailsPage|page({ (detailsUrlParameter): attribute(record, detailsKeyColumn) }) }}">
                 {% endif %}
@@ -19,7 +19,7 @@
                 {% if detailsPage %}
                     </a>
                 {% endif %}
-            {% endspaceless %}
+            {% endapply %}
         </li>
     {% else %}
         <li class="no-data">{{ noRecordsMessage }}</li>


### PR DESCRIPTION
In this PR `spaceless` tag is replaced with `apply spaceless` Twig filter. As documented in https://github.com/wintercms/meta/blob/master/l9-upgrade-notes.md#twig for Winter 1.2. Although `spaceless` is backported, I think this may avoid issues in future if for any reason backported `spaceless` would be removed.