### PR TITLE
Add "storm" option for the span property

### DIFF
--- a/classes/ControlLibrary.php
+++ b/classes/ControlLibrary.php
@@ -141,7 +141,8 @@ class ControlLibrary
                     'left' => Lang::get('winter.builder::lang.form.span_left'),
                     'right' => Lang::get('winter.builder::lang.form.span_right'),
                     'full' => Lang::get('winter.builder::lang.form.span_full'),
-                    'auto' => Lang::get('winter.builder::lang.form.span_auto')
+                    'auto' => Lang::get('winter.builder::lang.form.span_auto'),
+                    'storm' => Lang::get('winter.builder::lang.form.span_storm'),
                 ]
             ],
             'placeholder' => [

--- a/formwidgets/formbuilder/partials/_controllist.htm
+++ b/formwidgets/formbuilder/partials/_controllist.htm
@@ -2,6 +2,7 @@
     <?php
         $prevConfig = null;
         $prevSpan = null;
+        $cssClass = '';
 
         foreach ($controls as $controlName=>$controlConfig):
             $controlRenderingInfo = $this->getControlRenderingInfo($controlName, $controlConfig, $prevConfig);

--- a/formwidgets/formbuilder/partials/_controllist.htm
+++ b/formwidgets/formbuilder/partials/_controllist.htm
@@ -8,9 +8,13 @@
 
             $prevSpan = $controlConfig['span'] = $controlRenderingInfo['span'];
             $prevConfig = $controlConfig;
+            $cssClass = (
+                    ($controlRenderingInfo['span'] == 'storm' && isset($controlRenderingInfo['properties']['cssClass'])) ?
+                    $controlRenderingInfo['properties']['cssClass'] : 'col-sx-12 col-md-6'
+            );
     ?>
         <li
-            class="control <?= e($controlRenderingInfo['spanClass']) ?>"
+            class="control <?= e($controlRenderingInfo['spanClass']) ?> <?= e($cssClass) ?>"
             data-builder-span="<?= e($controlRenderingInfo['spanFixed']) ?>"
             <?php if (!$controlRenderingInfo['unknownControl']): ?>
             data-inspectable="true"

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -382,6 +382,7 @@ return [
         'span_right' => 'Right',
         'span_full' => 'Full',
         'span_auto' => 'Auto',
+        'span_storm' => 'Storm',
         'style_default' => 'Default',
         'style_collapsed' => 'Collapsed',
         'style_accordion' => 'Accordion',


### PR DESCRIPTION
Now is not possible to set "storm" as span value and the builder plugin delete the value saving after you set it manually.

We also apply the "cssClass" property to the widget of the builder if "storm" value is selected for the span property, default class "col-sx-12 col-md-6" will be applied if nothing is set

