### PR TITLE
Fix small layout issues in template

### DIFF
--- a/classes/controllergenerator/templates/controller.php.tpl
+++ b/classes/controllergenerator/templates/controller.php.tpl
@@ -5,10 +5,10 @@ use BackendMenu;
 
 class {{ controller }} extends Controller
 {
-    public $implement = [{% for behavior in behaviors %}
-        '{{ behavior }}'{% if not loop.last %},{% endif %}{% endfor %}
+    public $implement = [
+        {{ behaviors|map(b => "'" ~ b ~ "'")|join(",\n\t\t")|raw }}
     ];
-    {{ templateParts|raw }}
+{{ templateParts|raw }}
     public function __construct()
     {
         parent::__construct();

--- a/classes/controllergenerator/templates/controller.php.tpl
+++ b/classes/controllergenerator/templates/controller.php.tpl
@@ -6,7 +6,7 @@ use BackendMenu;
 class {{ controller }} extends Controller
 {
     public $implement = [
-        {{ behaviors|map(b => "'" ~ b ~ "'")|join(",\n\t\t")|raw }}
+        {{ behaviors|map(b => "'" ~ b ~ "'")|join(",\n        ")|raw }}
     ];
 {{ templateParts|raw }}
     public function __construct()


### PR DESCRIPTION
This is purely a cosmetic change to the Controller file created by builder.
When creating a controller using the builder plugin, your end file would have the following layout:

```php
{
    public $implement = [        'Backend\Behaviors\ListController',        'Backend\Behaviors\FormController'    ];
    # (added a comment here just to illustrate the whitespace)
    public $listConfig = 'config_list.yaml';
    public $formConfig = 'config_form.yaml';
```

Every time I edit a controller, I _need_ to fix the indentation and remove whitespaces otherwise I can´t sleep at night. This small fix does exactly that:

- It indents the code correcly
- It removes the extra spaces

```php
{
    public $implement = [
        'Backend\Behaviors\ListController',
        'Backend\Behaviors\FormController'
    ];
#comment here to show removed whitespace
    public $listConfig = 'config_list.yaml';
    public $formConfig = 'config_form.yaml';
```

