### PR TITLE
Winter v1.3 Support

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,4 +1,4 @@
-name: Tests
+name: Unit Tests
 
 on:
   push:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
+        operatingSystem: [ubuntu-latest, windows-latest]
         phpVersions: ['8.1', '8.2', '8.3', '8.4']
       fail-fast: false
     steps:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
-        phpVersions: ['8.1', '8.2', '8.3', '8.4']
+        phpVersions: ['8.2', '8.3', '8.4']
       fail-fast: false
     steps:
       - name: Setup Winter

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,6 +14,8 @@ jobs:
   phpUnitTests:
     name: ${{ matrix.operatingSystem }} / PHP ${{ matrix.phpVersion }}
     runs-on: ${{ matrix.operatingSystem }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.COMPOSER_PUBLIC_TOKEN }}
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   phpUnitTests:
-    name: PHP ${{ matrix.phpVersions }}
+    name: ${{ matrix.operatingSystem }} / PHP ${{ matrix.phpVersion }}
     runs-on: ${{ matrix.operatingSystem }}
     strategy:
       max-parallel: 4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'wip/1.3'
   pull_request:
 
 concurrency:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   phpUnitTests:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,13 +19,13 @@ jobs:
       max-parallel: 4
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
-        phpVersions: ['8.2', '8.3', '8.4']
+        phpVersion: ['8.2', '8.3', '8.4']
       fail-fast: false
     steps:
       - name: Setup Winter
         uses: wintercms/setup-winter-action@v1
         with:
-          php-version: ${{ matrix.phpVersions }}
+          php-version: ${{ matrix.phpVersion }}
           winter-ref: wip/1.3
           plugin-author: winter
           plugin-name: builder

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,79 +1,32 @@
-name: Unit Tests
+name: Tests
 
 on:
   push:
     branches:
-      - main
+      - 'main'
   pull_request:
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   phpUnitTests:
-    runs-on: ubuntu-latest
     name: PHP ${{ matrix.phpVersions }}
+    runs-on: ${{ matrix.operatingSystem }}
     strategy:
       max-parallel: 4
       matrix:
         phpVersions: ['8.1', '8.2', '8.3', '8.4']
       fail-fast: false
-    env:
-      phpExtensions: mbstring, intl, gd, xml, sqlite
-      cacheKey: ext-cache-v2
-      winterCmsRelease: develop
     steps:
-      - name: Checkout changes
-        uses: actions/checkout@v4
-        with:
-          path: builder-plugin
-
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
+      - name: Setup Winter
+        uses: wintercms/setup-winter-action@v1
         with:
           php-version: ${{ matrix.phpVersions }}
-          extensions: ${{ env.phpExtensions }}
-          key: ${{ env.cacheKey }}
-
-      - name: Cache extensions
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ steps.extcache.outputs.key }}
-
-      - name: Install PHP and extensions
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.phpVersions }}
-          extensions: ${{ env.phpExtensions }}
-          tools: composer:v2
-          coverage: none
-
-      - name: Install Winter CMS
-        run: |
-          wget https://github.com/wintercms/winter/archive/${{ env.winterCmsRelease }}.zip
-          unzip ${{ env.winterCmsRelease }}.zip
-          rm ${{ env.winterCmsRelease }}.zip
-          shopt -s dotglob
-          mv winter-${{ env.winterCmsRelease }}/* ./
-          rmdir winter-${{ env.winterCmsRelease }}
-          shopt -u dotglob
-          cp config/cms.php config/testing/cms.php
-          mkdir -p plugins/winter
-          mv builder-plugin plugins/winter/builder
-
-      - name: Get Composer cache directory
-        id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install Composer dependencies
-        run: composer install --no-interaction --no-progress
+          winter-ref: wip/1.3
+          plugin-author: winter
+          plugin-name: builder
 
       - name: Run unit tests
         run: php artisan winter:test -p Winter.Builder -- --testdox

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'wip/1.3'
   pull_request:
 
 concurrency:

--- a/classes/PhpSourceParser.php
+++ b/classes/PhpSourceParser.php
@@ -3,7 +3,6 @@
 namespace Winter\Builder\Classes;
 
 use PhpParser\Error;
-use PhpParser\Lexer\Emulative;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\NameResolver;
@@ -42,11 +41,6 @@ abstract class PhpSourceParser
     protected \PhpParser\NodeTraverser $traverser;
 
     /**
-     * The lexer used to manipulate code.
-     */
-    protected \PhpParser\Lexer\Emulative $lexer;
-
-    /**
      * The path to the parsed file, if loaded from a file.
      */
     protected ?string $filePath = null;
@@ -58,15 +52,7 @@ abstract class PhpSourceParser
      */
     public function __construct(string $source, string $file = null)
     {
-        $this->lexer = new Emulative([
-            'usedAttributes' => [
-                'comments',
-                'startLine', 'endLine',
-                'startTokenPos', 'endTokenPos',
-            ],
-        ]);
-
-        $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7, $this->lexer);
+        $parser = (new ParserFactory())->createForHostVersion();
 
         try {
             $this->originalAst = $parser->parse($source);
@@ -78,7 +64,7 @@ abstract class PhpSourceParser
             );
         }
 
-        $this->originalTokens = $this->lexer->getTokens();
+        $this->originalTokens = $parser->getTokens();
         $this->traverser = new NodeTraverser;
         $this->traverser->addVisitor(new CloningVisitor);
         $this->traverser->addVisitor(new NameResolver(null, [

--- a/classes/PhpSourceParser.php
+++ b/classes/PhpSourceParser.php
@@ -54,9 +54,6 @@ abstract class PhpSourceParser
     {
         $parser = (new ParserFactory())->createForHostVersion();
 
-        var_dump([\PHP_MAJOR_VERSION, \PHP_MINOR_VERSION]);
-        die();
-
         try {
             $this->originalAst = $parser->parse($source);
         } catch (Error $e) {

--- a/classes/PhpSourceParser.php
+++ b/classes/PhpSourceParser.php
@@ -54,6 +54,9 @@ abstract class PhpSourceParser
     {
         $parser = (new ParserFactory())->createForHostVersion();
 
+        var_dump([\PHP_MAJOR_VERSION, \PHP_MINOR_VERSION]);
+        die();
+
         try {
             $this->originalAst = $parser->parse($source);
         } catch (Error $e) {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": ">=7.0",
         "composer/installers": "~1.0",
-        "nikic/php-parser": "^4.13.2"
+        "nikic/php-parser": "^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    backupGlobals="false"
-    backupStaticAttributes="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="false"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
     <testsuites>

--- a/tests/BuilderPluginTestCase.php
+++ b/tests/BuilderPluginTestCase.php
@@ -1,16 +1,10 @@
-<?php namespace Winter\Builder\Tests;
+<?php
 
-if (class_exists('System\Tests\Bootstrap\PluginTestCase')) {
-    class BaseTestCase extends \System\Tests\Bootstrap\PluginTestCase
-    {
-    }
-} else {
-    class BaseTestCase extends \PluginTestCase
-    {
-    }
-}
+namespace Winter\Builder\Tests;
 
-abstract class BuilderPluginTestCase extends BaseTestCase
+use System\Tests\Bootstrap\PluginTestCase;
+
+abstract class BuilderPluginTestCase extends PluginTestCase
 {
     protected $refreshPlugins = [
         'Winter.Builder',

--- a/tests/unit/classes/FilesystemGeneratorTest.php
+++ b/tests/unit/classes/FilesystemGeneratorTest.php
@@ -1,8 +1,10 @@
-<?php namespace Winter\Builder\Tests\Unit\Classes;
+<?php
 
-use File;
+namespace Winter\Builder\Tests\Unit\Classes;
+
 use Winter\Builder\Classes\FilesystemGenerator;
 use Winter\Builder\Tests\BuilderPluginTestCase;
+use Winter\Storm\Support\Facades\File;
 
 class FilesystemGeneratorTest extends BuilderPluginTestCase
 {

--- a/tests/unit/classes/FilesystemGeneratorTest.php
+++ b/tests/unit/classes/FilesystemGeneratorTest.php
@@ -15,6 +15,8 @@ class FilesystemGeneratorTest extends BuilderPluginTestCase
 
     public function tearDown(): void
     {
+        parent::tearDown();
+
         $this->cleanUp();
     }
 

--- a/tests/unit/classes/MigrationFileParserTest.php
+++ b/tests/unit/classes/MigrationFileParserTest.php
@@ -2,18 +2,14 @@
 
 namespace Winter\Builder\Tests\Unit\Classes;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Winter\Builder\Classes\MigrationFileParser;
 use Winter\Builder\Tests\BuilderPluginTestCase;
 
-/**
- * @covers \Winter\Builder\Classes\MigrationFileParser
- */
+#[CoversClass(MigrationFileParser::class)]
 class MigrationFileParserTest extends BuilderPluginTestCase
 {
-   /**
-     * @testdox can determine if a file is a migration class definition.
-     */
-    public function testIsMigration()
+    public function test_it_can_determine_if_file_is_class_migration()
     {
         $firstMigration = MigrationFileParser::fromFile(
             __DIR__ . '/../../fixtures/pluginfixture/updates/create_simple_model_table.php'
@@ -30,10 +26,7 @@ class MigrationFileParserTest extends BuilderPluginTestCase
         $this->assertFalse($notAMigration->isMigration());
     }
 
-   /**
-     * @testdox can determine if a file is an anonymous class definition.
-     */
-    public function testIsAnonymous()
+    public function test_it_can_determine_if_file_is_anonymous_migration()
     {
         $firstMigration = MigrationFileParser::fromFile(
             __DIR__ . '/../../fixtures/pluginfixture/updates/create_simple_model_table.php'
@@ -50,10 +43,7 @@ class MigrationFileParserTest extends BuilderPluginTestCase
         $this->assertTrue($notAMigration->isAnonymous());
     }
 
-   /**
-     * @testdox can get the namespace of a class.
-     */
-    public function testGetNamespace()
+    public function test_it_can_get_namespace_of_class()
     {
         $firstMigration = MigrationFileParser::fromFile(
             __DIR__ . '/../../fixtures/pluginfixture/updates/create_simple_model_table.php'
@@ -70,10 +60,7 @@ class MigrationFileParserTest extends BuilderPluginTestCase
         $this->assertNull($notAMigration->getNamespace());
     }
 
-   /**
-     * @testdox can get the class name of a class.
-     */
-    public function testGetClassName()
+    public function test_it_can_get_class_name_of_class()
     {
         $firstMigration = MigrationFileParser::fromFile(
             __DIR__ . '/../../fixtures/pluginfixture/updates/create_simple_model_table.php'

--- a/tests/unit/classes/ModelFileParserTest.php
+++ b/tests/unit/classes/ModelFileParserTest.php
@@ -5,15 +5,10 @@ namespace Winter\Builder\Tests\Unit\Classes;
 use Winter\Builder\Classes\ModelFileParser;
 use Winter\Builder\Tests\BuilderPluginTestCase;
 
-/**
- * @covers \Winter\Builder\Classes\ModelFileParser
- */
+#[\PHPUnit\Framework\Attributes\CoversClass(ModelFileParser::class)]
 class ModelFileParserTest extends BuilderPluginTestCase
 {
-    /**
-     * @testdox can get information for the model from the parser.
-     */
-    public function testExtractModelInfoFromSource()
+    public function test_it_can_get_information_for_model_from_parser()
     {
         $parser = ModelFileParser::fromFile(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php');
         $modelInfo = $parser->extractModelInfoFromSource();
@@ -23,10 +18,7 @@ class ModelFileParserTest extends BuilderPluginTestCase
         $this->assertEquals('plugin_fixture_simple_model', $modelInfo['table']);
     }
 
-    /**
-     * @testdox can generate and provide the source code of a given model from the parser.
-     */
-    public function testGetSource()
+    public function test_it_can_generate_and_provide_source_of_given_model_from_parser()
     {
         $parser = ModelFileParser::fromFile(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php');
         $source = $parser->getSource();
@@ -34,10 +26,7 @@ class ModelFileParserTest extends BuilderPluginTestCase
         $this->assertEquals(file_get_contents(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php'), $source);
     }
 
-    /**
-     * @testdox can get the value of the $jsonable property from a model.
-     */
-    public function testGetJsonable()
+    public function test_it_can_get_value_of_jsonable_from_model()
     {
         $parser = ModelFileParser::fromFile(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php');
         $jsonable = $parser->getJsonable();
@@ -50,10 +39,7 @@ class ModelFileParserTest extends BuilderPluginTestCase
         ], $jsonable);
     }
 
-    /**
-     * @testdox can set the value of the $jsonable property in a model.
-     */
-    public function testSetJsonable()
+    public function test_it_can_set_value_of_jsonable_in_model()
     {
         $parser = ModelFileParser::fromFile(__DIR__ . '/../../fixtures/pluginfixture/models/ArrayDataModel.php');
         $parser->setJsonable([
@@ -65,10 +51,7 @@ class ModelFileParserTest extends BuilderPluginTestCase
         $this->assertStringContainsString('public $jsonable = [\'field_1\', \'field_2\'];', $source);
     }
 
-    /**
-     * @testdox can inject the $jsonable property in a model that does not contain it.
-     */
-    public function testSetJsonableAddProperty()
+    public function test_it_can_inject_jsonable_property_in_model_without_it()
     {
         $parser = ModelFileParser::fromFile(__DIR__ . '/../../fixtures/pluginfixture/models/SimpleModel.php');
         $parser->setJsonable([

--- a/tests/unit/classes/ModelModelTest.php
+++ b/tests/unit/classes/ModelModelTest.php
@@ -1,13 +1,13 @@
-<?php namespace Winter\Builder\Tests\Unit\Classes;
+<?php
 
-use SystemException;
+namespace Winter\Builder\Tests\Unit\Classes;
+
 use Winter\Builder\Classes\ModelModel;
 use Winter\Builder\Classes\PluginCode;
 use Winter\Builder\Tests\BuilderPluginTestCase;
+use Winter\Storm\Exception\SystemException;
 
-/**
- * @covers \Winter\Builder\Classes\ModelModel
- */
+#[\PHPUnit\Framework\Attributes\CoversClass(ModelModel::class)]
 class ModelModelTest extends BuilderPluginTestCase
 {
     public function tearDown(): void
@@ -18,10 +18,7 @@ class ModelModelTest extends BuilderPluginTestCase
         @unlink(__DIR__.'/../../../models/MyMock.php');
     }
 
-    /**
-     * @testdox validates valid model class names
-     */
-    public function testValidateValidModelClassNames()
+    public function test_it_validates_model_class_names()
     {
         $unQualifiedClassName = 'MyClassName';
         $this->assertTrue(ModelModel::validateModelClassName($unQualifiedClassName));
@@ -36,10 +33,7 @@ class ModelModelTest extends BuilderPluginTestCase
         $this->assertTrue(ModelModel::validateModelClassName($qualifiedClassNameStartingWithLowerCase));
     }
 
-    /**
-     * @testdox does not validate invalid model class names
-     */
-    public function testInvalidateInvalidModelClassNames()
+    public function test_it_does_not_validate_invalid_model_class_names()
     {
         $unQualifiedClassName = 'myClassName'; // starts with lower case
         $this->assertFalse(ModelModel::validateModelClassName($unQualifiedClassName));
@@ -51,10 +45,7 @@ class ModelModelTest extends BuilderPluginTestCase
         $this->assertFalse(ModelModel::validateModelClassName($fullyQualifiedClassName));
     }
 
-    /**
-     * @testdox can extract the model fields from a given model
-     */
-    public function testGetModelFields()
+    public function test_it_can_extract_model_fields_from_model()
     {
         // Invalid Class Name
         try {

--- a/tests/unit/classes/ModelModelTest.php
+++ b/tests/unit/classes/ModelModelTest.php
@@ -12,6 +12,8 @@ class ModelModelTest extends BuilderPluginTestCase
 {
     public function tearDown(): void
     {
+        parent::tearDown();
+
         // Ensure cleanup for testGetModelFields
         @unlink(__DIR__.'/../../../models/MyMock.php');
     }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -47,3 +47,4 @@
     - "Fixed an issue where migration files stored within subdirectories could not be read or saved."
     - "The permissions data table is now scrollable and will stretch to full height."
 "2.1.1": "Fix issue when creating new plugins"
+"2.2.0": "Support Winter v1.3+"


### PR DESCRIPTION
I've added support for php-parser v5, I tested and created a plugin and made some changes to that plugin and couldn't find anything broken, but anything that extends from our abstract `PhpSourceParser` may run into issues as the `lexer` property has been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with refactored test names for improved clarity and maintainability.

* **Chores**
  * Updated CI/CD pipeline to run tests across multiple operating systems and PHP versions (8.2, 8.3, 8.4).
  * Upgraded PHP parser dependency to v5.5.
  * Simplified PHPUnit configuration.
  * Released version 2.2.0 with support for Winter v1.3+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->